### PR TITLE
add check for incorrect command formatting for find by tag

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -16,10 +16,14 @@ public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "find";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ":\n1. Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
-            + "Example: " + COMMAND_WORD + " alice bob charlie";
+            + "Example: " + COMMAND_WORD + " alice bob charlie\n"
+            + "2. Finds all persons whose tag(s) (if present) matches the specified tag(s) and "
+            + "displays them as a list with index numbers.\n"
+            + "Parameters : t/TAG [MORE_TAGS]...\n"
+            + "Example: " + COMMAND_WORD + " t/friends family";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -31,7 +31,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         if (trimmedArgs.indexOf(PREFIX_TAG.getPrefix()) == 0) {
-            String[] tagKeywords = trimmedArgs.substring(2).split("\\s+");
+            String findTags = trimmedArgs.substring(2);
+            if (findTags.isEmpty()) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+            }
+            String[] tagKeywords = findTags.split("\\s+");
             return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
         } else {
             String[] nameKeywords = trimmedArgs.split("\\s+");


### PR DESCRIPTION
Checks for incorrect command format while finding a contact by tag(s). 
Eg: `find t/ ` will not be accepted as the tag keywords cannot be omitted.