### PR TITLE
Add unit testing for ExportCommand

### DIFF
--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -80,12 +80,18 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    /**
+     * Deletes a file if it exists.
+     */
     public static void deleteFileIfExists(Path file) throws IOException {
         if (isFileExists(file)) {
             deleteFile(file);
         }
     }
 
+    /**
+     * Deletes a file.
+     */
     public static void deleteFile(Path file) throws IOException {
         if (!Files.exists(file)) {
             return;

--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -80,4 +80,18 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    public static void deleteFileIfExists(Path file) throws IOException {
+        if (isFileExists(file)) {
+            deleteFile(file);
+        }
+    }
+
+    public static void deleteFile(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            return;
+        }
+
+        Files.delete(file);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -42,6 +42,12 @@ public class ExportCommand extends Command {
         this.fileName = fileName;
     }
 
+    /**
+     * Creates an ExportCommand with a custom filePath for testing purposes.
+     *
+     * @param testPath Path where the JSON file will be exported to.
+     * @param fileName Name of the JSON file.
+     */
     public ExportCommand(String testPath, String fileName) {
         requireNonNull(fileName);
         this.testPath = testPath;

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -28,6 +28,7 @@ public class ExportCommand extends Command {
 
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
 
+    private final String testPath;
     private final String fileName;
 
     /**
@@ -37,12 +38,19 @@ public class ExportCommand extends Command {
      */
     public ExportCommand(String fileName) {
         requireNonNull(fileName);
+        this.testPath = "";
+        this.fileName = fileName;
+    }
+
+    public ExportCommand(String testPath, String fileName) {
+        requireNonNull(fileName);
+        this.testPath = testPath;
         this.fileName = fileName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        Path filePath = Path.of(fileName + ".json");
+        Path filePath = Path.of(testPath + fileName + ".json");
         JsonAddressBookStorage temporaryStorage = new JsonAddressBookStorage(filePath);
         try {
             temporaryStorage.exportToJson(model.getAddressBook());

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.util.FileUtil;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ExportCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private static final String PATH_FILE_CREATED_FOLDER = "src/test/data/ExportCommandTest/FileDoesNotExist/";
+    private static final String PATH_FILE_EXISTS_FOLDER = "src/test/data/ExportCommandTest/FileExists/";
+    private static final String TEST_FILE_NAME = "testFile";
+
+    @Test
+    public void equals() {
+        ExportCommand exportFirstCommand = new ExportCommand("first");
+        ExportCommand exportSecondCommand = new ExportCommand("second");
+
+        // same object -> returns true
+        assertTrue(exportFirstCommand.equals(exportFirstCommand));
+
+        // same filename -> returns true
+        assertTrue(exportFirstCommand.equals(new ExportCommand("first")));
+
+        // different types -> returns false
+        assertFalse(exportFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(exportFirstCommand.equals(null));
+
+        // different filename -> returns false
+        assertFalse(exportFirstCommand.equals(exportSecondCommand));
+    }
+
+    /**
+     * Export command creates a file when there is no existing file with the given name.
+     * Test file is deleted after creation.
+     * Test occurs in src/test/data/ExportCommandTest/FileDoesNotExist.
+     */
+    @Test
+    public void execute_fileName_fileCreated() {
+        String expectedMessage = String.format(ExportCommand.MESSAGE_EXPORT_SUCCESS, TEST_FILE_NAME);
+
+        ExportCommand exportCommand = new ExportCommand(PATH_FILE_CREATED_FOLDER, TEST_FILE_NAME);
+        assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
+        try {
+            FileUtil.deleteFileIfExists(Path.of(PATH_FILE_CREATED_FOLDER + TEST_FILE_NAME + ".json"));
+        } catch (IOException ioe) {
+            System.out.println("Error deleting testFile.json");
+        }
+    }
+
+    /**
+     * Export command fails when there is an existing file with the given name.
+     * Test occurs in src/test/data/ExportCommandTest/FileExists.
+     */
+    @Test
+    public void execute_fileName_fileExists() {
+        String expectedMessage = String.format(ExportCommand.MESSAGE_EXPORT_FAILURE, TEST_FILE_NAME);
+        ExportCommand exportCommand = new ExportCommand(PATH_FILE_EXISTS_FOLDER, TEST_FILE_NAME);
+        assertCommandFailure(exportCommand, model, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -6,10 +6,8 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import org.junit.jupiter.api.Test;
 
@@ -19,12 +17,14 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
 public class ExportCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
     private static final String PATH_FILE_CREATED_FOLDER = "src/test/data/ExportCommandTest/FileDoesNotExist/";
     private static final String PATH_FILE_EXISTS_FOLDER = "src/test/data/ExportCommandTest/FileExists/";
     private static final String TEST_FILE_NAME = "testFile";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+
 
     @Test
     public void equals() {


### PR DESCRIPTION
Changes:
* ExportCommandTest.java
* New folder `src/test/data/ExportCommandTest` to simulate environments for testing export
* Created 2 new methods in `FileUtil.java`: `deleteFileIfExists(Path)` and `deleteFile(Path)`. This is mainly for deleting the testFile created after testing ExportCommand, in the folder mentioned earlier.
* New class variable `testPath` and overloaded constructor in ExportCommand to specify file path for testing purposes. This is create some separation between the file name and path. So when executing ExportCommand, the success message will be dependent on the file name ONLY, regardless of the file path.