### PR TITLE
Add find by telegram handle(s) feature

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -23,7 +23,11 @@ public class FindCommand extends Command {
             + "2. Finds all persons whose tag(s) (if present) matches the specified tag(s) and "
             + "displays them as a list with index numbers.\n"
             + "Parameters : t/TAG [MORE_TAGS]...\n"
-            + "Example: " + COMMAND_WORD + " t/friends family";
+            + "Example: " + COMMAND_WORD + " t/friends family"
+            + "\n3. Finds all persons whose telegram handles(s) (if present) matches the specified telegram "
+            + "handle(s) and displays them as a list with index numbers.\n"
+            + "Parameters : t/TELEGRAM_HANDLE [MORE_TELEGRAM_HANDLES]...\n"
+            + "Example: " + COMMAND_WORD + " @alex_1";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -9,18 +9,67 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
-
-
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    private static String tagIdentifier = PREFIX_TAG.getPrefix();
+    private static String telegramHandleIdentifier = "@";
+
+    /**
+     * Parses the list of names to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 name to search for
+     */
+    public FindCommand parseFindName(String trimmedArgs) throws ParseException {
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    /**
+     * Parses the list of tags to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 tag to search for
+     */
+    public FindCommand parseFindTag(String trimmedArgs) throws ParseException {
+        String tags = trimmedArgs.substring(2).trim();
+        if (tags.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        String[] tagKeywords = tags.split("\\s+");
+        return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+    }
+
+    /**
+     * Parses the list of telegram handles to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 telegram handle to search for
+     */
+    public FindCommand parseFindTelegramHandle(String trimmedArgs) throws ParseException {
+        String telegramHandles = trimmedArgs.substring(1).trim();
+        if (telegramHandles.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        String[] telegramHandleKeywords = telegramHandles.split("\\s+");
+        return new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
+                .asList(telegramHandleKeywords)));
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
@@ -30,17 +79,12 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (trimmedArgs.indexOf(PREFIX_TAG.getPrefix()) == 0) {
-            String findTags = trimmedArgs.substring(2);
-            if (findTags.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-            String[] tagKeywords = findTags.split("\\s+");
-            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+        if (trimmedArgs.indexOf(tagIdentifier) == 0) {
+            return parseFindTag(trimmedArgs);
+        } else if (trimmedArgs.indexOf(telegramHandleIdentifier) == 0) {
+            return parseFindTelegramHandle(trimmedArgs);
         } else {
-            String[] nameKeywords = trimmedArgs.split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            return parseFindName(trimmedArgs);
         }
     }
 }

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
@@ -17,8 +15,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        String name = person.getName().fullName.toLowerCase();
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> name.contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Telegram} matches any of the keywords given.
+ */
+public class TelegramHandleContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TelegramHandleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        String telegramHandle = person.getTelegram().value.toLowerCase();
+        return keywords.stream()
+                .anyMatch(keyword -> telegramHandle.contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TelegramHandleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TelegramHandleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -19,6 +22,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -55,9 +60,9 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
+    public void execute_zeroNameKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -65,19 +70,120 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
+    public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_zeroTagKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/ ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTagKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/friends");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/owesMoney family");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, ELLE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_noPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/colleague classmate");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_zeroTelegramHandleKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@ ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTelegramHandleKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@meier");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTelegramHandleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@meier ku");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, CARL, DANIEL, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTelegramHandleKeywords_noPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@anonym10 pennywise1");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
+     */
+    private TagContainsKeywordsPredicate prepareTagPredicate(String userInput) {
+        String tags = userInput.substring(2).trim();
+        return new TagContainsKeywordsPredicate(Arrays.asList(tags.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
+     */
+    private TelegramHandleContainsKeywordsPredicate prepareTelegramHandlePredicate(String userInput) {
+        String telegramHandles = userInput.substring(1).trim();
+        return new TelegramHandleContainsKeywordsPredicate(Arrays
+                .asList(telegramHandles.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -174,7 +174,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
      */
     private TagContainsKeywordsPredicate prepareTagPredicate(String userInput) {
-        String tags = userInput.substring(2).trim();
+        String tags = userInput.substring(2);
         return new TagContainsKeywordsPredicate(Arrays.asList(tags.split("\\s+")));
     }
 
@@ -182,7 +182,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
      */
     private TelegramHandleContainsKeywordsPredicate prepareTelegramHandlePredicate(String userInput) {
-        String telegramHandles = userInput.substring(1).trim();
+        String telegramHandles = userInput.substring(1);
         return new TelegramHandleContainsKeywordsPredicate(Arrays
                 .asList(telegramHandles.split("\\s+")));
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -17,18 +19,43 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
-
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays
+                        .asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays
+                        .asList("friends", "family")));
+        assertParseSuccess(parser, "t/friends family", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "t/\n friends \n \t family  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTelegramHandleArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
+                        .asList("alex_1", "bern")));
+        assertParseSuccess(parser, "@alex_1 bern", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "@\n alex_1 \n \t bern  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -39,7 +39,8 @@ public class TypicalPersons {
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
             .withTelegram("daniel_meier").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withTelegram("elle_meyer").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withTags("family").withTelegram("elle_meyer")
+            .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withTelegram("fiona_kunz").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")


### PR DESCRIPTION
Add command `find t/TELEGRAM_HANDLE [MORE_TELEGRAM_HANDLES]`
E.g. If user the user wants to search for contacts with telegram handles alex_1 and bern, they would enter `find @alex_1 bern`
List of contacts with the exact telegram handles/ that contain the following handles as substrings will be displayed.
