### PR TITLE
Add a Show Command to show user details

### DIFF
--- a/src/main/java/seedu/address/commons/util/FileUtil.java
+++ b/src/main/java/seedu/address/commons/util/FileUtil.java
@@ -80,4 +80,24 @@ public class FileUtil {
         Files.write(file, content.getBytes(CHARSET));
     }
 
+    /**
+     * Deletes a file if it exists.
+     */
+    public static void deleteFileIfExists(Path file) throws IOException {
+        if (isFileExists(file)) {
+            deleteFile(file);
+        }
+    }
+
+    /**
+     * Deletes a file.
+     */
+    public static void deleteFile(Path file) throws IOException {
+        if (!Files.exists(file)) {
+            return;
+        }
+
+        Files.delete(file);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/ExportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExportCommand.java
@@ -28,6 +28,7 @@ public class ExportCommand extends Command {
 
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
 
+    private final String testPath;
     private final String fileName;
 
     /**
@@ -37,12 +38,25 @@ public class ExportCommand extends Command {
      */
     public ExportCommand(String fileName) {
         requireNonNull(fileName);
+        this.testPath = "";
+        this.fileName = fileName;
+    }
+
+    /**
+     * Creates an ExportCommand with a custom filePath for testing purposes.
+     *
+     * @param testPath Path where the JSON file will be exported to.
+     * @param fileName Name of the JSON file.
+     */
+    public ExportCommand(String testPath, String fileName) {
+        requireNonNull(fileName);
+        this.testPath = testPath;
         this.fileName = fileName;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        Path filePath = Path.of(fileName + ".json");
+        Path filePath = Path.of(testPath + fileName + ".json");
         JsonAddressBookStorage temporaryStorage = new JsonAddressBookStorage(filePath);
         try {
             temporaryStorage.exportToJson(model.getAddressBook());

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -23,7 +23,11 @@ public class FindCommand extends Command {
             + "2. Finds all persons whose tag(s) (if present) matches the specified tag(s) and "
             + "displays them as a list with index numbers.\n"
             + "Parameters : t/TAG [MORE_TAGS]...\n"
-            + "Example: " + COMMAND_WORD + " t/friends family";
+            + "Example: " + COMMAND_WORD + " t/friends family"
+            + "\n3. Finds all persons whose telegram handles(s) (if present) matches the specified telegram "
+            + "handle(s) and displays them as a list with index numbers.\n"
+            + "Parameters : t/TELEGRAM_HANDLE [MORE_TELEGRAM_HANDLES]...\n"
+            + "Example: " + COMMAND_WORD + " @alex_1";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ImportCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ImportCommand.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.nio.file.Path;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.exceptions.DataConversionException;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.storage.JsonAddressBookStorage;
+
+public class ImportCommand extends Command {
+
+    public static final String COMMAND_WORD = "import";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Imports contacts from a specified JSON file.\n"
+            + "Parameters: FILENAME\n"
+            + "Example: " + COMMAND_WORD + " friends";
+
+    public static final String MESSAGE_IMPORT_SUCCESS = "Imported from file: %s.json";
+
+    public static final String MESSAGE_IMPORT_FILE_NOT_FOUND = "File with name &s.json could not be found!";
+
+    public static final String MESSAGE_IMPORT_FILE_WRONG_TYPE = "%s is in the wrong format!";
+
+    private final String testPath;
+    private final String fileName;
+
+
+    /**
+     * Creates an ImportCommand to import contacts from a specified file.
+     *
+     * @param fileName Name of the JSON file.
+     */
+    public ImportCommand(String fileName) {
+        requireNonNull(fileName);
+        this.testPath = "";
+        this.fileName = fileName;
+    }
+
+    /**
+     * Creates an ImportCommand with a custom filePath for testing purposes.
+     *
+     * @param testPath Path to the folder where the JSON file will be exported to.
+     * @param fileName Name of the JSON file.
+     */
+    public ImportCommand(String testPath, String fileName) {
+        requireNonNull(fileName);
+        this.testPath = testPath;
+        this.fileName = fileName;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Path filePath = Path.of(testPath + fileName + ".json");
+        JsonAddressBookStorage temporaryStorage = new JsonAddressBookStorage(filePath);
+        Optional<ReadOnlyAddressBook> addressBookOptional;
+        ReadOnlyAddressBook fileData;
+        try {
+            addressBookOptional = temporaryStorage.readAddressBook();
+            fileData = addressBookOptional.orElseThrow();
+        } catch (DataConversionException dce) {
+            throw new CommandException(String.format(MESSAGE_IMPORT_FILE_WRONG_TYPE, fileName));
+        } catch (NoSuchElementException nsee) {
+            throw new CommandException(String.format(MESSAGE_IMPORT_FILE_NOT_FOUND, fileName));
+        }
+        ObservableList<Person> personList = fileData.getPersonList();
+        for (Person p: personList) {
+            try {
+                model.addPerson(p);
+            } catch (DuplicatePersonException dpe) {
+                // skip current person if it already exists
+                continue;
+            }
+        }
+        return new CommandResult(String.format(MESSAGE_IMPORT_SUCCESS, fileName));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ImportCommand // instanceof handles nulls
+                && fileName.equals(((ImportCommand) other).fileName)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -15,6 +15,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.ExportCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ShowCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -75,6 +76,9 @@ public class AddressBookParser {
 
         case ShowCommand.COMMAND_WORD:
             return new ShowCommandParser().parse(arguments);
+
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -9,18 +9,67 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.TagContainsKeywordsPredicate;
-
-
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 
 /**
  * Parses input arguments and creates a new FindCommand object
  */
 public class FindCommandParser implements Parser<FindCommand> {
+    private static String tagIdentifier = PREFIX_TAG.getPrefix();
+    private static String telegramHandleIdentifier = "@";
+
+    /**
+     * Parses the list of names to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 name to search for
+     */
+    public FindCommand parseFindName(String trimmedArgs) throws ParseException {
+        String[] nameKeywords = trimmedArgs.split("\\s+");
+        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+    }
+
+    /**
+     * Parses the list of tags to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 tag to search for
+     */
+    public FindCommand parseFindTag(String trimmedArgs) throws ParseException {
+        String tags = trimmedArgs.substring(2).trim();
+        if (tags.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        String[] tagKeywords = tags.split("\\s+");
+        return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+    }
+
+    /**
+     * Parses the list of telegram handles to be searched for in the context of the FindCommand
+     * and returns a FindCommand object for execution.
+     *
+     * @return FindCommand object for execution.
+     * @throws ParseException if user has not entered at least 1 telegram handle to search for
+     */
+    public FindCommand parseFindTelegramHandle(String trimmedArgs) throws ParseException {
+        String telegramHandles = trimmedArgs.substring(1).trim();
+        if (telegramHandles.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        }
+        String[] telegramHandleKeywords = telegramHandles.split("\\s+");
+        return new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
+                .asList(telegramHandleKeywords)));
+    }
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {
@@ -30,17 +79,12 @@ public class FindCommandParser implements Parser<FindCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        if (trimmedArgs.indexOf(PREFIX_TAG.getPrefix()) == 0) {
-            String findTags = trimmedArgs.substring(2);
-            if (findTags.isEmpty()) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
-            }
-            String[] tagKeywords = findTags.split("\\s+");
-            return new FindCommand(new TagContainsKeywordsPredicate(Arrays.asList(tagKeywords)));
+        if (trimmedArgs.indexOf(tagIdentifier) == 0) {
+            return parseFindTag(trimmedArgs);
+        } else if (trimmedArgs.indexOf(telegramHandleIdentifier) == 0) {
+            return parseFindTelegramHandle(trimmedArgs);
         } else {
-            String[] nameKeywords = trimmedArgs.split("\\s+");
-            return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+            return parseFindName(trimmedArgs);
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ImportCommandParser.java
@@ -1,0 +1,39 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new ImportCommand object.
+ */
+public class ImportCommandParser implements Parser<ImportCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ImportCommand
+     * and returns an ImportCommand object for execution.
+     *
+     * @param args String that user enters.
+     * @return ImportCommand
+     * @throws ParseException If the user input does not conform to the expected format.
+     */
+    public ImportCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        String[] fileNameKeywords = trimmedArgs.split("\\s+");
+
+        if (fileNameKeywords.length > 1) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ImportCommand.MESSAGE_USAGE));
+        }
+
+        String fileName = fileNameKeywords[0];
+
+        return new ImportCommand(fileName);
+    }
+}

--- a/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/NameContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package seedu.address.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import seedu.address.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */

--- a/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/TelegramHandleContainsKeywordsPredicate.java
@@ -1,0 +1,29 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Person}'s {@code Telegram} matches any of the keywords given.
+ */
+public class TelegramHandleContainsKeywordsPredicate implements Predicate<Person> {
+    private final List<String> keywords;
+
+    public TelegramHandleContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        String telegramHandle = person.getTelegram().value.toLowerCase();
+        return keywords.stream()
+                .anyMatch(keyword -> telegramHandle.contains(keyword.toLowerCase()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof TelegramHandleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((TelegramHandleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -34,7 +34,7 @@
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tagged" : [ ]
+    "tagged" : [ "family" ]
   }, {
     "name" : "Fiona Kunz",
     "telegram": "fiona_kunz",

--- a/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExportCommandTest.java
@@ -1,0 +1,78 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.util.FileUtil;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class ExportCommandTest {
+    private static final String PATH_FILE_CREATED_FOLDER = "src/test/data/ExportCommandTest/FileDoesNotExist/";
+    private static final String PATH_FILE_EXISTS_FOLDER = "src/test/data/ExportCommandTest/FileExists/";
+    private static final String TEST_FILE_NAME = "testFile";
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+
+
+    @Test
+    public void equals() {
+        ExportCommand exportFirstCommand = new ExportCommand("first");
+        ExportCommand exportSecondCommand = new ExportCommand("second");
+
+        // same object -> returns true
+        assertTrue(exportFirstCommand.equals(exportFirstCommand));
+
+        // same filename -> returns true
+        assertTrue(exportFirstCommand.equals(new ExportCommand("first")));
+
+        // different types -> returns false
+        assertFalse(exportFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(exportFirstCommand.equals(null));
+
+        // different filename -> returns false
+        assertFalse(exportFirstCommand.equals(exportSecondCommand));
+    }
+
+    /**
+     * Export command creates a file when there is no existing file with the given name.
+     * Test file is deleted after creation.
+     * Test occurs in src/test/data/ExportCommandTest/FileDoesNotExist.
+     */
+    @Test
+    public void execute_fileName_fileCreated() {
+        String expectedMessage = String.format(ExportCommand.MESSAGE_EXPORT_SUCCESS, TEST_FILE_NAME);
+
+        ExportCommand exportCommand = new ExportCommand(PATH_FILE_CREATED_FOLDER, TEST_FILE_NAME);
+        assertCommandSuccess(exportCommand, model, expectedMessage, expectedModel);
+        try {
+            FileUtil.deleteFileIfExists(Path.of(PATH_FILE_CREATED_FOLDER + TEST_FILE_NAME + ".json"));
+        } catch (IOException ioe) {
+            System.out.println("Error deleting testFile.json");
+        }
+    }
+
+    /**
+     * Export command fails when there is an existing file with the given name.
+     * Test occurs in src/test/data/ExportCommandTest/FileExists.
+     */
+    @Test
+    public void execute_fileName_fileExists() {
+        String expectedMessage = String.format(ExportCommand.MESSAGE_EXPORT_FAILURE, TEST_FILE_NAME);
+        ExportCommand exportCommand = new ExportCommand(PATH_FILE_EXISTS_FOLDER, TEST_FILE_NAME);
+        assertCommandFailure(exportCommand, model, expectedMessage);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -5,7 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSONS_LISTED_OVERVIEW;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BENSON;
 import static seedu.address.testutil.TypicalPersons.CARL;
+import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
@@ -19,6 +22,8 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -55,9 +60,9 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_zeroKeywords_noPersonFound() {
+    public void execute_zeroNameKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -65,19 +70,120 @@ public class FindCommandTest {
     }
 
     @Test
-    public void execute_multipleKeywords_multiplePersonsFound() {
+    public void execute_multipleNameKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        NameContainsKeywordsPredicate predicate = prepareNamePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredPersonList());
     }
 
+    @Test
+    public void execute_zeroTagKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/ ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTagKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/friends");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(ALICE, BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/owesMoney family");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, ELLE), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTagKeywords_noPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TagContainsKeywordsPredicate predicate = prepareTagPredicate("t/colleague classmate");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_zeroTelegramHandleKeywords_noPersonFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@ ");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_oneTelegramHandleKeyword_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@meier");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, DANIEL), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTelegramHandleKeywords_multiplePersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@meier ku");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BENSON, CARL, DANIEL, FIONA), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_multipleTelegramHandleKeywords_noPersonsFound() {
+        String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        TelegramHandleContainsKeywordsPredicate predicate =
+                prepareTelegramHandlePredicate("@anonym10 pennywise1");
+        FindCommand command = new FindCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
     /**
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
+    private NameContainsKeywordsPredicate prepareNamePredicate(String userInput) {
         return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
+     */
+    private TagContainsKeywordsPredicate prepareTagPredicate(String userInput) {
+        String tags = userInput.substring(2);
+        return new TagContainsKeywordsPredicate(Arrays.asList(tags.split("\\s+")));
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
+     */
+    private TelegramHandleContainsKeywordsPredicate prepareTelegramHandlePredicate(String userInput) {
+        String telegramHandles = userInput.substring(1);
+        return new TelegramHandleContainsKeywordsPredicate(Arrays
+                .asList(telegramHandles.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
+import seedu.address.model.person.TagContainsKeywordsPredicate;
+import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
 
 public class FindCommandParserTest {
 
@@ -17,18 +19,43 @@ public class FindCommandParserTest {
 
     @Test
     public void parse_emptyArg_throwsParseException() {
-        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "     ",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
-
     @Test
-    public void parse_validArgs_returnsFindCommand() {
+    public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays
+                        .asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " \n Alice \n \t Bob  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTagArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TagContainsKeywordsPredicate(Arrays
+                        .asList("friends", "family")));
+        assertParseSuccess(parser, "t/friends family", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "t/\n friends \n \t family  \t", expectedFindCommand);
+    }
+
+    @Test
+    public void parse_validTelegramHandleArgs_returnsFindCommand() {
+        // no leading and trailing whitespaces
+        FindCommand expectedFindCommand =
+                new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
+                        .asList("alex_1", "bern")));
+        assertParseSuccess(parser, "@alex_1 bern", expectedFindCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, "@\n alex_1 \n \t bern  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -39,7 +39,8 @@ public class TypicalPersons {
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
             .withTelegram("daniel_meier").build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
-            .withEmail("werner@example.com").withAddress("michegan ave").withTelegram("elle_meyer").build();
+            .withEmail("werner@example.com").withAddress("michegan ave").withTags("family").withTelegram("elle_meyer")
+            .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withTelegram("fiona_kunz").build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")


### PR DESCRIPTION
This resolves #49 by adding the show command with the following formats:

## **Format 1**: `show #index`
If the argument is a number it is taken to be an index, and details of contact at index is shown

## **Format 2**: `show name`
If the argument is a string then it is taken to be a name, and details of contact with that name is shown
If there is more than one user with that name then it display list of the users with that name

