### PR TITLE
Add change to format of find by telegram handle

### DIFF
--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -26,8 +26,8 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " t/friends family"
             + "\n3. Finds all persons whose telegram handles(s) (if present) matches the specified telegram "
             + "handle(s) and displays them as a list with index numbers.\n"
-            + "Parameters : t/TELEGRAM_HANDLE [MORE_TELEGRAM_HANDLES]...\n"
-            + "Example: " + COMMAND_WORD + " @alex_1";
+            + "Parameters : te/TELEGRAM_HANDLE [MORE_TELEGRAM_HANDLES]...\n"
+            + "Example: " + COMMAND_WORD + " te/alex_1 yuBernice";
 
     private final Predicate<Person> predicate;
 

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TELEGRAM;
 
 import java.util.Arrays;
 
@@ -17,7 +18,7 @@ import seedu.address.model.person.TelegramHandleContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
     private static String tagIdentifier = PREFIX_TAG.getPrefix();
-    private static String telegramHandleIdentifier = "@";
+    private static String telegramHandleIdentifier = PREFIX_TELEGRAM.getPrefix();
 
     /**
      * Parses the list of names to be searched for in the context of the FindCommand
@@ -56,7 +57,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * @throws ParseException if user has not entered at least 1 telegram handle to search for
      */
     public FindCommand parseFindTelegramHandle(String trimmedArgs) throws ParseException {
-        String telegramHandles = trimmedArgs.substring(1).trim();
+        String telegramHandles = trimmedArgs.substring(3).trim();
         if (telegramHandles.isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
@@ -64,6 +65,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         String[] telegramHandleKeywords = telegramHandles.split("\\s+");
         return new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
                 .asList(telegramHandleKeywords)));
+    }
+    private boolean isValidFormat(String trimmedArgs) {
+        boolean isTag = trimmedArgs.indexOf(tagIdentifier) == 0;
+        boolean isTelegram = trimmedArgs.indexOf(telegramHandleIdentifier) == 0;
+        boolean isName = !trimmedArgs.contains("/") && Character.isLetter(trimmedArgs.charAt(0));
+        return isTag || isTelegram || isName;
     }
 
     /**
@@ -74,7 +81,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
-        if (trimmedArgs.isEmpty()) {
+        if (trimmedArgs.isEmpty() || !isValidFormat(trimmedArgs)) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -50,7 +50,7 @@ public class SampleDataUtil {
                     new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
                     getTagSet("family")),
             new Person(new Name("Irfan Ibrahim"),
-                    new Telegram("irfan-ibrahim"),
+                    new Telegram("irfan_ibrahim"),
                     new Github("irfan-ibrahim"),
                     new Phone("92492021"),
                     new Email("irfan@example.com"),

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -123,7 +123,7 @@ public class FindCommandTest {
     public void execute_zeroTelegramHandleKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         TelegramHandleContainsKeywordsPredicate predicate =
-                prepareTelegramHandlePredicate("@ ");
+                prepareTelegramHandlePredicate("te/ ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -134,7 +134,7 @@ public class FindCommandTest {
     public void execute_oneTelegramHandleKeyword_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
         TelegramHandleContainsKeywordsPredicate predicate =
-                prepareTelegramHandlePredicate("@meier");
+                prepareTelegramHandlePredicate("te/meier");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -145,7 +145,7 @@ public class FindCommandTest {
     public void execute_multipleTelegramHandleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 4);
         TelegramHandleContainsKeywordsPredicate predicate =
-                prepareTelegramHandlePredicate("@meier ku");
+                prepareTelegramHandlePredicate("te/meier ku");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -156,7 +156,7 @@ public class FindCommandTest {
     public void execute_multipleTelegramHandleKeywords_noPersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         TelegramHandleContainsKeywordsPredicate predicate =
-                prepareTelegramHandlePredicate("@anonym10 pennywise1");
+                prepareTelegramHandlePredicate("te/anonym10 pennywise1");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -182,7 +182,7 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code TagContainsKeywordsPredicate}.
      */
     private TelegramHandleContainsKeywordsPredicate prepareTelegramHandlePredicate(String userInput) {
-        String telegramHandles = userInput.substring(1);
+        String telegramHandles = userInput.substring(3);
         return new TelegramHandleContainsKeywordsPredicate(Arrays
                 .asList(telegramHandles.split("\\s+")));
     }

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -22,6 +22,19 @@ public class FindCommandParserTest {
         assertParseFailure(parser, "     ",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_invalidArg1_throwsParseException() {
+        assertParseFailure(parser, "@alex",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidArg2_throwsParseException() {
+        assertParseFailure(parser, "tele/alex",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
+    }
+
     @Test
     public void parse_validNameArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
@@ -52,10 +65,10 @@ public class FindCommandParserTest {
         FindCommand expectedFindCommand =
                 new FindCommand(new TelegramHandleContainsKeywordsPredicate(Arrays
                         .asList("alex_1", "bern")));
-        assertParseSuccess(parser, "@alex_1 bern", expectedFindCommand);
+        assertParseSuccess(parser, "te/alex_1 bern", expectedFindCommand);
 
         // multiple whitespaces between keywords
-        assertParseSuccess(parser, "@\n alex_1 \n \t bern  \t", expectedFindCommand);
+        assertParseSuccess(parser, "te/\n alex_1 \n \t bern  \t", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -11,7 +11,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
 import seedu.address.model.person.Telegram;
 import seedu.address.model.tag.Tag;
-import seedu.address.model.util.SampleDataUtil;
+import seedu.address.model.util.Util;
 
 /**
  * A utility class to help with building Person objects.


### PR DESCRIPTION
Users can search by telegram handle(s) by typing `find te/[TELEGRAM_HANDLE]`.