### PR TITLE
Add clickable Github username

### DIFF
--- a/src/main/java/seedu/address/ui/PersonDetails.java
+++ b/src/main/java/seedu/address/ui/PersonDetails.java
@@ -29,6 +29,7 @@ public class PersonDetails extends UiPart<Region> {
 
     private static final String FXML = "PersonDetails.fxml";
     private static final String TELEGRAM_URL_PREFIX = "https://t.me/";
+    private static final String GITHUB_URL_PREFIX = "https://github.com/";
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     /**
@@ -78,12 +79,14 @@ public class PersonDetails extends UiPart<Region> {
         name.setText(person.getName().fullName);
         String teleUrl = TELEGRAM_URL_PREFIX + person.getTelegram();
         telegram.setText("@" + person.getTelegram().value);
+        String githubUrl = GITHUB_URL_PREFIX + person.getGithub();
         github.setText(person.getGithub().value);
         tags.getChildren().removeIf(c -> true);
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
         telegram.setOnMouseClicked((event) -> openTelegram(teleUrl));
+        github.setOnMouseClicked((event) -> openGithub(githubUrl));
         if (person.getPhone().value.isBlank()) {
             phone.setText("-");
         } else {
@@ -122,12 +125,26 @@ public class PersonDetails extends UiPart<Region> {
         try {
             Desktop.getDesktop().browse(new URL(teleUrl).toURI());
         } catch (IOException e) {
-            logger.severe("Could not open browser to show link to telegram.");
+            logger.severe("Could not open browser to show link to Telegram.");
         } catch (URISyntaxException e) {
-            logger.severe("URL to telegram not formatted well.");
+            logger.severe("URL to Telegram not formatted well.");
         }
     }
 
+    /**
+     * Opens the link to the person's Github profile in the default web browser on
+     * the system.
+     */
+    @FXML
+    public void openGithub(String githubUrl) {
+        try {
+            Desktop.getDesktop().browse(new URL(githubUrl).toURI());
+        } catch (IOException e) {
+            logger.severe("Could not open browser to show link to Github.");
+        } catch (URISyntaxException e) {
+            logger.severe("URL to Github not formatted well.");
+        }
+    }
     @Override
     public boolean equals(Object other) {
         // short circuit if same object

--- a/src/main/resources/view/PersonDetails.fxml
+++ b/src/main/resources/view/PersonDetails.fxml
@@ -45,7 +45,7 @@
                         <Insets bottom="10.0" />
                      </VBox.margin>
                   </Label>
-                  <Label fx:id="telegram" style="-fx-text-fill: #e8e8e8; -fx-font-size: 15px;" text="Label" textFill="#e8e8e8" underline="true">
+                  <Label fx:id="telegram" style="-fx-text-fill: #84ddf3; -fx-font-size: 15px;" text="Label" textFill="#84ddf3" underline="true">
                      <VBox.margin>
                         <Insets bottom="5.0" />
                      </VBox.margin>
@@ -60,7 +60,7 @@
                         <Insets bottom="10.0" />
                      </VBox.margin>
                   </Label>
-                  <Label fx:id="github" style="-fx-text-fill: #e8e8e8#e8e8e8; -fx-font-size: 15px;" text="Label" textFill="#e8e8e8">
+                  <Label fx:id="github" style="-fx-text-fill: #84ddf3; -fx-font-size: 15px;" text="Label" textFill="#e8e8e8" underline="true">
                      <VBox.margin>
                         <Insets bottom="5.0" />
                      </VBox.margin>


### PR DESCRIPTION
Users can now directly go to their contact's Github profile by clicking on their Github username.