### PR TITLE
Update telegram regex.

### DIFF
--- a/src/main/java/seedu/address/model/person/Telegram.java
+++ b/src/main/java/seedu/address/model/person/Telegram.java
@@ -12,7 +12,7 @@ public class Telegram {
     public static final String MESSAGE_CONSTRAINTS =
             "Telegram should only contain alphabets,numbers or underscore,"
                     + " and it should be between 5 to 64 characters long ";
-    public static final String VALIDATION_REGEX = "\\w{5,64}";
+    public static final String VALIDATION_REGEX = "\\w{5,32}";
     public final String value;
 
     /**


### PR DESCRIPTION
Changed regex to accommodate a maximum telegram handle length of 32 characters long.