### PR TITLE
Fix bug for incorrect "unknown" command message

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -17,4 +17,7 @@ public class Messages {
             + "be empty.";
     public static final String MESSAGE_GITHUB_FIELD_CANNOT_BE_EMPTY = "Invalid format! Github field cannot "
             + "be empty.";
+    public static final String MESSAGE_COMMAND_DESCRIPTION_CANNOT_BE_EMPTY = " command description cannot be empty!";
+    public static final String MESSAGE_COMMAND_DOES_NOT_TAKE_PARAMETERS = " command doesn't take parameters!";
+    public static final String MESSAGE_PARSE_COMMAND_ERROR = "Error encountered while parsing command!";
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -1,8 +1,13 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_COMMAND_DESCRIPTION_CANNOT_BE_EMPTY;
+import static seedu.address.commons.core.Messages.MESSAGE_COMMAND_DOES_NOT_TAKE_PARAMETERS;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_PARSE_COMMAND_ERROR;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -28,6 +33,7 @@ import seedu.address.logic.commands.TelegramCommand;
 import seedu.address.logic.commands.UnfavouriteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+
 /**
  * Parses user input.
  */
@@ -38,6 +44,74 @@ public class AddressBookParser {
      */
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
+    private ArrayList<String> commandsWithDescription =
+            new ArrayList<>(Arrays.asList(AddCommand.COMMAND_WORD, EditCommand.COMMAND_WORD,
+                    DeleteCommand.COMMAND_WORD, FavouriteCommand.COMMAND_WORD,
+                    UnfavouriteCommand.COMMAND_WORD, FindCommand.COMMAND_WORD, ExportCommand.COMMAND_WORD,
+                    ShowCommand.COMMAND_WORD, ImportCommand.COMMAND_WORD, TagCommand.COMMAND_WORD)
+            );
+    private ArrayList<String> commandsWithoutDescription =
+            new ArrayList<>(Arrays.asList(ClearCommand.COMMAND_WORD, ExitCommand.COMMAND_WORD,
+                    HelpCommand.COMMAND_WORD, TelegramCommand.COMMAND_WORD, GithubCommand.COMMAND_WORD,
+                    ListCommand.COMMAND_WORD)
+            );
+
+    /**
+     * Parses user input into command (that doesn't accept arguments) for execution.
+     * @param commandWord command type
+     * @return the command based on the user input
+     */
+    public Command parseCommandWithoutDescription(String commandWord) throws ParseException {
+        switch (commandWord) {
+        case ClearCommand.COMMAND_WORD:
+            return new ClearCommand();
+        case ExitCommand.COMMAND_WORD:
+            return new ExitCommand();
+        case HelpCommand.COMMAND_WORD:
+            return new HelpCommand();
+        case TelegramCommand.COMMAND_WORD:
+            return new TelegramCommand();
+        case GithubCommand.COMMAND_WORD:
+            return new GithubCommand();
+        case ListCommand.COMMAND_WORD:
+            return new ListCommand();
+        default :
+            throw new ParseException(MESSAGE_PARSE_COMMAND_ERROR);
+        }
+    }
+
+    /**
+     * Parses user input into command (that accepts arguments) for execution.
+     * @param commandWord command type
+     * @return the command based on the user input
+     */
+    public Command parseCommandWithDescription(String commandWord, String arguments) throws ParseException {
+        switch (commandWord) {
+        case AddCommand.COMMAND_WORD:
+            return new AddCommandParser().parse(arguments);
+        case EditCommand.COMMAND_WORD:
+            return new EditCommandParser().parse(arguments);
+        case DeleteCommand.COMMAND_WORD:
+            return new DeleteCommandParser().parse(arguments);
+        case FavouriteCommand.COMMAND_WORD:
+            return new FavouriteCommandParser().parse(arguments);
+        case UnfavouriteCommand.COMMAND_WORD:
+            return new UnfavouriteCommandParser().parse(arguments);
+        case FindCommand.COMMAND_WORD:
+            return new FindCommandParser().parse(arguments);
+        case ExportCommand.COMMAND_WORD:
+            return new ExportCommandParser().parse(arguments);
+        case ShowCommand.COMMAND_WORD:
+            return new ShowCommandParser().parse(arguments);
+        case ImportCommand.COMMAND_WORD:
+            return new ImportCommandParser().parse(arguments);
+        case TagCommand.COMMAND_WORD:
+            return new TagCommandParser().parse(arguments);
+        default:
+            throw new ParseException(MESSAGE_PARSE_COMMAND_ERROR);
+        }
+    }
+
     /**
      * Parses user input into command for execution.
      *
@@ -56,67 +130,20 @@ public class AddressBookParser {
         logger.info("----------------[COMMAND WORD][" + commandWord + "]");
         final String arguments = matcher.group("arguments");
         logger.info("----------------[ARGUMENTS][" + arguments + "]");
-
-        if (arguments.isBlank()) {
-            switch (commandWord) {
-            case ClearCommand.COMMAND_WORD:
-                return new ClearCommand();
-
-            case ExitCommand.COMMAND_WORD:
-                return new ExitCommand();
-
-            case HelpCommand.COMMAND_WORD:
-                return new HelpCommand();
-
-            case TelegramCommand.COMMAND_WORD:
-                return new TelegramCommand();
-
-            case GithubCommand.COMMAND_WORD:
-                return new GithubCommand();
-
-            case ListCommand.COMMAND_WORD:
-                return new ListCommand();
-
-            default:
-                throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
+        final boolean isCommandWithDescription = commandsWithDescription.contains(commandWord);
+        final boolean isCommandWithoutDescription = commandsWithoutDescription.contains(commandWord);
+        if (isCommandWithDescription) {
+            if (arguments.isEmpty()) {
+                throw new ParseException(commandWord + MESSAGE_COMMAND_DESCRIPTION_CANNOT_BE_EMPTY);
             }
-        }
-
-        switch (commandWord) {
-
-        case AddCommand.COMMAND_WORD:
-            return new AddCommandParser().parse(arguments);
-
-        case EditCommand.COMMAND_WORD:
-            return new EditCommandParser().parse(arguments);
-
-        case DeleteCommand.COMMAND_WORD:
-            return new DeleteCommandParser().parse(arguments);
-
-        case FavouriteCommand.COMMAND_WORD:
-            return new FavouriteCommandParser().parse(arguments);
-
-        case UnfavouriteCommand.COMMAND_WORD:
-            return new UnfavouriteCommandParser().parse(arguments);
-
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
-        case ExportCommand.COMMAND_WORD:
-            return new ExportCommandParser().parse(arguments);
-
-        case ShowCommand.COMMAND_WORD:
-            return new ShowCommandParser().parse(arguments);
-
-        case ImportCommand.COMMAND_WORD:
-            return new ImportCommandParser().parse(arguments);
-
-        case TagCommand.COMMAND_WORD:
-            return new TagCommandParser().parse(arguments);
-
-        default:
+            return parseCommandWithDescription(commandWord, arguments);
+        } else if (isCommandWithoutDescription) {
+            if (!arguments.isEmpty()) {
+                throw new ParseException(commandWord + MESSAGE_COMMAND_DOES_NOT_TAKE_PARAMETERS);
+            }
+            return parseCommandWithoutDescription(commandWord);
+        } else {
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
-
 }


### PR DESCRIPTION
Now when a user enters just the command keyword with no description for command like `find  ` , `edit  `,  `add  `, etc. that take in parameters, an error message saying "<command_name> command cannot have an empty description!" will be shown instead of the "unknown command" earlier.

Similarly, when a user enters the command keyword with extraneous parameters for commands like `list  `,  `clear `,  `exit  `, etc. that don't take in any parameters, an error message saying "<command_name> command does not take any parameters!" will be shown instead of the "unknown command" earlier.

Closes #235.