### PR TITLE
Fix GUI bug for `UnfavouriteCommand`.

### DIFF
--- a/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UnfavouriteCommand.java
@@ -47,6 +47,8 @@ public class UnfavouriteCommand extends Command {
         model.unfavouritePerson(personToUnfavourite);
         if (model.getPersonListControl() != null) {
             model.getPersonListControl().refreshPersonListUI();
+            model.getPersonListControl().setTabIndex(0);
+            model.getPersonListControl().setTabIndex(1);
         }
         String successMessage = personToUnfavourite.getName().toString()
                 + MESSAGE_UNFAVOURITE_PERSON_SUCCESS;


### PR DESCRIPTION
The Unfavourite command will remove a contact from the favourite tab instantly.
![image](https://user-images.githubusercontent.com/72136453/140608004-b0e06ff5-e19d-4570-99e8-c7ade0b8739b.png)
