### PR TITLE
Fix edit command error messages.

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -69,8 +69,6 @@ public class EditCommandParser implements Parser<EditCommand> {
         Index index = ParserUtil.parseIndex("1");
         boolean isProfile = false;
         try {
-            System.out.println("arg" + argMultimap.getPreamble() + "/");
-            System.out.println(argMultimap.getPreamble().equals(""));
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             if (argMultimap.getPreamble().equals("profile")) {

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -77,7 +77,7 @@ public class EditCommandParser implements Parser<EditCommand> {
                 isProfile = true;
                 checkEditProfileInputFormat(args, argMultimap);
             } else {
-                throw new ParseException(pe.getMessage() + "\n" + EditCommand.MESSAGE_USAGE);
+                throw new ParseException(pe.getMessage() + " \n" + EditCommand.MESSAGE_USAGE);
             }
         }
 

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.EditCommand.MESSAGE_EDIT_PROFILE_GITHUB_CANNOT_BE_EMPTY;
 import static seedu.address.logic.commands.EditCommand.MESSAGE_EDIT_PROFILE_NAME_CANNOT_BE_EMPTY;
 import static seedu.address.logic.commands.EditCommand.MESSAGE_EDIT_PROFILE_PARAMETERS_CANNOT_BE_EMPTY;

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -70,13 +70,15 @@ public class EditCommandParser implements Parser<EditCommand> {
         Index index = ParserUtil.parseIndex("1");
         boolean isProfile = false;
         try {
+            System.out.println("arg" + argMultimap.getPreamble() + "/");
+            System.out.println(argMultimap.getPreamble().equals(""));
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
             if (argMultimap.getPreamble().equals("profile")) {
                 isProfile = true;
                 checkEditProfileInputFormat(args, argMultimap);
             } else {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+                throw new ParseException(pe.getMessage() + "\n" + EditCommand.MESSAGE_USAGE);
             }
         }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -35,7 +35,6 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
-        System.out.println("empty" + trimmedIndex.isEmpty());
         if (trimmedIndex.isEmpty()) {
             throw new ParseException(MESSAGE_MISSING_INDEX);
         } else {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -35,14 +35,18 @@ public class ParserUtil {
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
+        System.out.println("empty" + trimmedIndex.isEmpty());
         if (trimmedIndex.isEmpty()) {
             throw new ParseException(MESSAGE_MISSING_INDEX);
-        } else if (trimmedIndex.contains("/")) {
-            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
-        } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
         } else {
-            return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+            String[] indexWords = trimmedIndex.split(" ");
+            if (indexWords.length > 1) {
+                throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT);
+            } else if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
+                throw new ParseException(MESSAGE_INVALID_INDEX);
+            } else {
+                return Index.fromOneBased(Integer.parseInt(trimmedIndex));
+            }
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -69,35 +69,46 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_missingParts_failure() {
-        // no index specified
-        assertParseFailure(parser, VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        // no prefix specified
+        String expectedMessageMissingPrefix = ParserUtil.MESSAGE_INVALID_COMMAND_FORMAT
+                + " \n" + EditCommand.MESSAGE_USAGE;
+        assertParseFailure(parser, VALID_NAME_AMY, expectedMessageMissingPrefix);
 
         // no field specified
         assertParseFailure(parser, "1", MESSAGE_NOT_EDITED);
 
+        String expectedMessageMissingIndex = ParserUtil.MESSAGE_MISSING_INDEX
+                + " \n" + EditCommand.MESSAGE_USAGE;
         // no index and no field specified
-        assertParseFailure(parser, "", MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, "", expectedMessageMissingIndex);
     }
 
     @Test
     public void parse_missingPartsProfile_failure() {
-        // no index specified
-        assertParseFailure(parser, PROFILE + " " + VALID_NAME_AMY, MESSAGE_INVALID_FORMAT);
+        // no prefix specified
+        String expectedMessageMissingPrefix = ParserUtil.MESSAGE_INVALID_COMMAND_FORMAT
+                + " \n" + EditCommand.MESSAGE_USAGE;
+        assertParseFailure(parser, PROFILE + " " + VALID_NAME_AMY, expectedMessageMissingPrefix);
 
         // no field specified
         assertParseFailure(parser, PROFILE + " " + "1", MESSAGE_INVALID_FORMAT);
 
+        String expectedMessageMissingIndex = "At least one field to edit must be provided.";
         // no index and no field specified
-        assertParseFailure(parser, PROFILE + " " + "", MESSAGE_NOT_EDITED);
+        assertParseFailure(parser, PROFILE + " " + "", expectedMessageMissingIndex);
     }
 
     @Test
     public void parse_invalidPreamble_failure() {
         // negative index
-        assertParseFailure(parser, "-5" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        String expectedErrorNegativeIndex = ParserUtil.MESSAGE_INVALID_INDEX
+                + " \n" + EditCommand.MESSAGE_USAGE;
+        assertParseFailure(parser, "-5" + NAME_DESC_AMY, expectedErrorNegativeIndex);
 
         // zero index
-        assertParseFailure(parser, "0" + NAME_DESC_AMY, MESSAGE_INVALID_FORMAT);
+        String expectedErrorZeroIndex = ParserUtil.MESSAGE_INVALID_INDEX
+                + " \n" + EditCommand.MESSAGE_USAGE;
+        assertParseFailure(parser, "0" + NAME_DESC_AMY, expectedErrorZeroIndex);
 
         // invalid arguments being parsed as preamble
         assertParseFailure(parser, "1 some random string", MESSAGE_INVALID_FORMAT);


### PR DESCRIPTION
The parser will now be able to determine if:
* No index provided
![image](https://user-images.githubusercontent.com/72136453/140633821-aabdb7f2-8d9d-43d8-bbab-d762ae3ace87.png)
* Invalid index
![image](https://user-images.githubusercontent.com/72136453/140633830-a13bb512-8836-49e8-9267-a5246ca7bc24.png)
* Invalid command format
![image](https://user-images.githubusercontent.com/72136453/140633850-d53f0d27-aa76-462b-8f31-a04070933d77.png)
